### PR TITLE
fix: invalid version url

### DIFF
--- a/templates/apps/basic/imports.json
+++ b/templates/apps/basic/imports.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "alosaur/": "https://deno.land/x/alosaur@v.0.28.0/"
+    "alosaur/": "https://deno.land/x/alosaur@v0.34.0/"
   }
 }

--- a/templates/apps/cors/imports.json
+++ b/templates/apps/cors/imports.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "alosaur/": "https://deno.land/x/alosaur@v.0.28.0/"
+    "alosaur/": "https://deno.land/x/alosaur@v0.34.0/"
   }
 }

--- a/templates/apps/db/imports.json
+++ b/templates/apps/db/imports.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "alosaur/": "https://deno.land/x/alosaur@v.0.28.0/",
+    "alosaur/": "https://deno.land/x/alosaur@v0.34.0/",
     "postgres/": "https://deno.land/x/postgres/"
   }
 }

--- a/templates/apps/default/imports.json
+++ b/templates/apps/default/imports.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "alosaur/": "https://deno.land/x/alosaur@v.0.28.0/"
+    "alosaur/": "https://deno.land/x/alosaur@v0.34.0/"
   }
 }

--- a/templates/apps/handlebars/imports.json
+++ b/templates/apps/handlebars/imports.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "alosaur/": "https://deno.land/x/alosaur@v.0.28.0/",
+    "alosaur/": "https://deno.land/x/alosaur@v0.34.0/",
     "handlebars/": "https://deno.land/x/handlebars@v0.2.2/"
   }
 }

--- a/templates/apps/spa/imports.json
+++ b/templates/apps/spa/imports.json
@@ -1,5 +1,5 @@
 {
   "imports": {
-    "alosaur/": "https://deno.land/x/alosaur@v.0.28.0/"
+    "alosaur/": "https://deno.land/x/alosaur@v0.34.0/"
   }
 }

--- a/templates/apps/static/imports.json
+++ b/templates/apps/static/imports.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "alosaur/": "https://deno.land/x/alosaur@v.0.28.0/",
+    "alosaur/": "https://deno.land/x/alosaur@v0.34.0/",
     "http/": "https://deno.land/x/std/http/"
   }
 }

--- a/templates/generate/area.template
+++ b/templates/generate/area.template
@@ -1,4 +1,4 @@
-import { Area } from "https://deno.land/x/alosaur@v0.28.0/mod.ts";
+import { Area } from "https://deno.land/x/alosaur@v0.34.0/mod.ts";
 
 @Area({
     controllers: [],

--- a/templates/generate/controller.template
+++ b/templates/generate/controller.template
@@ -1,4 +1,4 @@
-import { Controller, Get } from "https://deno.land/x/alosaur@v0.28.0/mod.ts";
+import { Controller, Get } from "https://deno.land/x/alosaur@v0.34.0/mod.ts";
 
 @Controller('{{name}}')
 export class {{#classify}}{{name}}{{/classify}}Controller {

--- a/templates/generate/hook.template
+++ b/templates/generate/hook.template
@@ -1,4 +1,4 @@
-import { HookTarget, Context } from "https://deno.land/x/alosaur@v0.28.0/mod.ts";
+import { HookTarget, Context } from "https://deno.land/x/alosaur@v0.34.0/mod.ts";
 
 type PayloadType = string;
 type State = any;

--- a/templates/generate/middleware.template
+++ b/templates/generate/middleware.template
@@ -1,4 +1,4 @@
-import { Middleware, Context } from "https://deno.land/x/alosaur@v0.28.0/mod.ts";
+import { Middleware, Context } from "https://deno.land/x/alosaur@v0.34.0/mod.ts";
 
 @Middleware(new RegExp("/"))
 export class {{#classify}}{{name}}{{/classify}}Middleware implements MiddlewareTarget<TState> {

--- a/templates/generate/service.template
+++ b/templates/generate/service.template
@@ -1,4 +1,4 @@
-import { Injectable } from "https://deno.land/x/alosaur@v0.28.0/mod.ts";
+import { Injectable } from "https://deno.land/x/alosaur@v0.34.0/mod.ts";
 
 @Injectable()
 export class {{#classify}}{{name}}{{/classify}}Service {


### PR DESCRIPTION
- Fix broken url version
- Update to 0.34.0

If you try to follow getting started tutorial, you will to fail in:

```
deno run --allow-net --allow-read --importmap=imports.json --config ./tsconfig.json app.ts
```

Because this version link is broken.

<img width="412" alt="Captura de Tela 2021-09-29 às 21 20 40" src="https://user-images.githubusercontent.com/11943860/135366096-c3f8ce5e-22c4-4e42-a75e-0e8c2d225bfc.png">
